### PR TITLE
Update fmv/fsh/fmv.h.x/fmv.x.h to instructions to indicate presence in zvfbfwma

### DIFF
--- a/doc/insns/flh.adoc
+++ b/doc/insns/flh.adoc
@@ -28,6 +28,9 @@ Included in::
 | <<zFBFMIN>>
 | v0.0.1
 | Initial
+| <<zvfbfwma>>
+| v0.0.1
+| Initial
 |===
 
 

--- a/doc/insns/fmv_h_x.adoc
+++ b/doc/insns/fmv_h_x.adoc
@@ -30,6 +30,9 @@ Included in::
 | <<zFBFMIN>>
 | v0.0.1
 | Initial
+| <<zvfbfwma>>
+| v0.0.1
+| Initial
 |===
 
 

--- a/doc/insns/fmv_x_h.adoc
+++ b/doc/insns/fmv_x_h.adoc
@@ -30,6 +30,9 @@ Included in::
 | <<zFBFMIN>>
 | v0.0.1
 | Initial
+| <<zvfbfwma>>
+| v0.0.1
+| Initial
 |===
 
 

--- a/doc/insns/fsh.adoc
+++ b/doc/insns/fsh.adoc
@@ -29,6 +29,9 @@ Included in::
 | <<zFBFMIN>>
 | v0.0.1
 | Initial
+| <<zvfbfwma>>
+| v0.0.1
+| Initial
 |===
 
 


### PR DESCRIPTION
These instructions were recently added to zvbfwma (as opposed to having a dependency on zfh or zfhmin), but the insns/*.adoc files weren't updated to reflect this.