### PR TITLE
Add zfbfinxmin extension

### DIFF
--- a/doc/insns/fcvt_BF16_S.adoc
+++ b/doc/insns/fcvt_BF16_S.adoc
@@ -65,6 +65,9 @@ Included in::
 | <<zfbfmin>>
 | v0.0.1
 | Initial
+| <<zfbfinxmin>>
+| v0.0.1
+| Initial
 |===
 
 

--- a/doc/insns/fcvt_S_BF16.adoc
+++ b/doc/insns/fcvt_S_BF16.adoc
@@ -55,6 +55,9 @@ Included in::
 | <<zfbfmin>>
 | v0.0.1
 | Initial
+| <<zfbfinxmin>>
+| v0.0.1
+| Initial
 |===
 
 

--- a/doc/riscv-bfloat16-extensions.adoc
+++ b/doc/riscv-bfloat16-extensions.adoc
@@ -19,5 +19,6 @@ The BF16 extensions defined in this specification depend on the single-precision
 This initial set of BF16 extensions provides very basic functionality including scalar and vector conversion between BF16 and single-precision values, and vector widening multiply-add instructions.
 
 include::riscv-bfloat16-zfbfmin.adoc[]
+include::riscv-bfloat16-zfbfinxmin.adoc[]
 include::riscv-bfloat16-zvfbfmin.adoc[]
 include::riscv-bfloat16-zvfbfwma.adoc[]

--- a/doc/riscv-bfloat16-zfbfinxmin.adoc
+++ b/doc/riscv-bfloat16-zfbfinxmin.adoc
@@ -1,0 +1,29 @@
+[[zfbfinxmin,Zfbfinxmin]]
+=== `Zfbfinxmin` - Scalar BF16 Converts In Integer Registers
+
+This extension provides the minimal set of instructions needed to enable scalar support
+of the BF16 format on platforms using the `Zfinx` family of extensions (where
+floating point instructions operate on `x` registers rather than `f`
+registers). It enables BF16 as an interchange format as it provides conversion
+between BF16 values and FP32 values. It requires the `Zfinx` extension.
+
+As `FLH`, `FSH`, `FMX.X.H`, and `FMX.H.X` are unnecessary in the absence of
+`f` registers, it defines only two instructions: `FCVT.BF16.S` and
+`FCVT.S.BF16`. These instructions have the same semantics as they do within
+the `Zfbfmin` extension, except that whenever such an instruction would have
+accessed an `f` register, it instead accesses the `x` register with the same
+number.
+
+As with the other floating-point in integer register extensions, floating
+point operands of width `w < XLEN` bits occupy bits `w-1:0` of an `x`
+register.  Floating-point operations on `w`-bit operands ignore operand bits
+`XLEN-1:w`. Floating point operations that produce `w < XLEN`-bit results fill
+`XLEN-1:w` with copies of bit `w-1` (the sign bit).
+[%autowidth]
+[%header,cols="2,4"]
+|===
+|Mnemonic
+|Instruction
+|FCVT.BF16.S    | <<insns-fcvt.bf16.s>>
+|FCVT.S.BF16    | <<insns-fcvt.s.bf16>>
+|===


### PR DESCRIPTION
With Zfinx, Zdinx, Zhinx, and Zhinxmin there's a clear precedent that floating point extensions should have an analogous "inx" version. As defining such a variant is straight-forward, I feel it would be most sensible (and efficient) to define it as part of the bfloat16 definition process rather than leaving a gap within the ISA to be filled at a later date.

This drafts such a definition. As the bfloat16 extensions are defined in new documentation rather than patches to the riscv-isa-manual, I've duplicated some explanatory text from the Zfinx chapater of the manual so that the zfbfinxmin definition makes sense standalone. If merging into the ISA manual, it would of course take a different form.

Fixes #27.