### PR TITLE
Zfbmin->Zfbfmin, Zvfbwma->Zvfbfwma

### DIFF
--- a/doc/riscv-bfloat16-format.adoc
+++ b/doc/riscv-bfloat16-format.adoc
@@ -55,8 +55,8 @@ by the format's smallest exponent value with a "0" integer bit and at least one 
 in the trailing fractional bits are called subnormal numbers. Basically, the idea is there is
 a trade off of precision to support _gradual underflow_.
 
-All of the BF16 instructions in the extensions defined in this specification (i.e., Zfbmin, Zvfbfmin
-and Zvfbwma) fully support subnormal numbers. That is, instructions are able to accept subnormal values as
+All of the BF16 instructions in the extensions defined in this specification (i.e., Zfbfmin, Zvfbfmin
+and Zvfbfwma) fully support subnormal numbers. That is, instructions are able to accept subnormal values as
 inputs and they can produce subnormal results.
 
 

--- a/doc/riscv-bfloat16-zfbfmin.adoc
+++ b/doc/riscv-bfloat16-zfbfmin.adoc
@@ -8,7 +8,7 @@ between BF16 values and FP32 values.
 This extension includes the `FLH`, `FSH`, `FMV.X.H`, and `FMV.H.X` instructions
 that are defined in the `Zfh` spec.
 
-// Requiring Zfbmin adds the following "extra" instructions:
+// Requiring Zfbfmin adds the following "extra" instructions:
 //
 // - `FCVT.S.H`, and `FCVT.H.S`
 // - If D: `FCVT.D.H` and `FCVT.H.D`


### PR DESCRIPTION
This fixes a couple visible typos in the generated spec