### PR TITLE
Cleaning-up vfwmaccbf16

### DIFF
--- a/doc/insns/vfwmaccbf16.adoc
+++ b/doc/insns/vfwmaccbf16.adoc
@@ -55,34 +55,39 @@ Arguments::
 |===
 
 Description:: 
-This instruction perfoms a wideing fused multiply-accumulate operation, when each pair of BF16 values
+This instruction performs a widening fused multiply-accumulate operation, when each pair of BF16 values
 are multiplied and their unrounded product is added to the corresponding FP32 accumulate value. The
 sum is rounded to FP32.
 In the vector-vector version, the BF16 elements are read from `vs1` and `vs2` and
 FP32 accumulate value is read from `vd`.
 The vector-scalar version is similar, but instead of reading elements from `vs1`, a scalar BF16 value is
 read from the FPU register `rs1`.  
-The FP32 result is written to the destination register `rd`.
+The FP32 result is written to the destination register `vd`.
 
 Exceptions: Overflow, Underflow, Inexact, Invalid
 
 Operation::
+
+This instruction is equivalent to widening each of the BF16 inputs to FP32 and then performing an FMACC.
+
+Thus `vfwmaccbf16.vv` is equivalent to the following instruction sequence:
+
+[source,asm]
 --
-This instruction is equivelent to widening each of the BF16 inputs to FP32 and then performing an FMACC.
-
-Thus vfwmaccbf16.vv is equivalent to the following instruction sequence:
-
-vfwcvtbf16.f.f.v T1, vs1, vm +
-vfwcvtbf16.f.f.v T2, vs2, vm +
-vfmacc.vv vd, T1, T2, vm
-
-Likewise, vfwmaccbf16.vs is equivalent to the following instruction sequence:
-
-fcvt.s.bf16 T1, rs1 +
-vfwcvtbf16.f.f.v T2, vs2, vm +
-vfmacc.vv vd, T1, T2, vm
-
+vfwcvtbf16.f.f.v T1, vs1, vm
+vfwcvtbf16.f.f.v T2, vs2, vm
+vfmacc.vv        vd, T1, T2, vm
 --
+
+Likewise, `vfwmaccbf16.vs` is equivalent to the following instruction sequence:
+
+[source,asm]
+--
+fcvt.s.bf16      T1, rs1
+vfwcvtbf16.f.f.v T2, vs2, vm
+vfmacc.vv        vd, T1, T2, vm
+--
+
 
 Included in::
 [%header,cols="4,2,2"]


### PR DESCRIPTION
Fuse https://github.com/riscv/riscv-bfloat16/pull/41 + https://github.com/riscv/riscv-bfloat16/pull/42
Plus a few other cleanups

I had to change the structure of `Operation::` to get the assembly sequence to display properly (maybe this part is unwarranted so I am not going to close the two previous PRs just yet).