### PR TITLE
Add missed quotes for vfwmaccbf16

### DIFF
--- a/doc/insns/vfwmaccbf16.adoc
+++ b/doc/insns/vfwmaccbf16.adoc
@@ -18,7 +18,7 @@ Encoding (Vector-Vector)::
 {bits: 5, name: 'vs1'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: 'vm'},
-{bits: 6, name: 111011, attr:['vfwmaccbf16']},
+{bits: 6, name: '111011', attr:['vfwmaccbf16']},
 ]}
 ....
 
@@ -32,7 +32,7 @@ Encoding (Vector-Scalar)::
 {bits: 5, name: 'rs1'},
 {bits: 5, name: 'vs2'},
 {bits: 1, name: 'vm'},
-{bits: 6, name: 111011, attr:['vfwmaccbf16']},
+{bits: 6, name: '111011', attr:['vfwmaccbf16']},
 ]}
 ....
 // funct6=111011


### PR DESCRIPTION
I encountered the same problem as issue https://github.com/riscv/riscv-bfloat16/issues/45 when I tried to update the support for BF16 extensions in Spike and QEMU. 
I'm not familiar with the adoc format. However I think quotes are missed for it, since all the name of other fields have quotes. 