### PR TITLE
Typo fix: FVCT -> FCVT

### DIFF
--- a/doc/insns/fcvt_BF16_S.adoc
+++ b/doc/insns/fcvt_BF16_S.adoc
@@ -17,7 +17,7 @@ Encoding::
 {bits: 5, name: 'rs1'},
 {bits: 5, name: '01000', attr: ['BF16.S']},
 {bits: 2, name: '10', attr: ['H']},
-{bits: 5, name: '01000', attr: 'FVCT'},
+{bits: 5, name: '01000', attr: 'FCVT'},
 ]}
 ....
 // S.B16 = 001,S=00

--- a/doc/insns/fcvt_S_BF16.adoc
+++ b/doc/insns/fcvt_S_BF16.adoc
@@ -17,7 +17,7 @@ Encoding::
 {bits: 5, name: 'rs1'},
 {bits: 5, name: '00110', attr: ['BF16']},
 {bits: 2, name: '00', attr: ['S']},
-{bits: 5, name: '01000', attr: 'FVCT'},
+{bits: 5, name: '01000', attr: 'FCVT'},
 ]}
 ....
 


### PR DESCRIPTION
I believe this is a typo.