### PR TITLE
Clarifying dependencies in riscv-bfloat16-extensions.adoc

### DIFF
--- a/doc/riscv-bfloat16-extensions.adoc
+++ b/doc/riscv-bfloat16-extensions.adoc
@@ -18,6 +18,8 @@ The BF16 extensions defined in this specification (i.e., `Zfbfmin`,
 `F`. Furthermore, the vector BF16 extensions (i.e.,`Zvfbfmin`, and
 `Zvfbfwma`) depend on the `"V"` Vector Extension for Application
 Processors or the `Zve32f` Vector Extension for Embedded Processors.
+Finally there exist dependencies between the newly defined extensions:
+`Zvfbfmin` depends on `Zfbfmin` and `Zvfbfwma` depends on `Zvfbfmin`.
 
 This initial set of BF16 extensions provides very basic functionality
 including  scalar and vector conversion between BF16 and


### PR DESCRIPTION
Only a subset of the dependencies of the new extensions are listed in `riscv-bfloat16-extensions.adoc`. This could be a bit confusing, this PR suggests a correction by listing all the dependencies, including the ones between the new extensions.