### PR TITLE
Use ghcr.io/riscv/riscv-docs-base-container-image:latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # the Doc Template for RISC-V Extensions.
 
 DOCKER_RUN := docker run --rm -v ${PWD}:/build -w /build \
-riscvintl/riscv-docs-base-container-image:latest
+ghcr.io/riscv/riscv-docs-base-container-image:latest
 
 HEADER_SOURCE := doc/riscv-bfloat16.adoc
 PDF_RESULT := riscv-bfloat16.pdf


### PR DESCRIPTION
This updates the docs container image reference in the root Makefile.

The old `riscvintl` image has been replaced with the `ghcr.io/riscv` image.
